### PR TITLE
Fix(Tabs): Multiple tabs

### DIFF
--- a/src/components/documentViewer/documentViewer.js
+++ b/src/components/documentViewer/documentViewer.js
@@ -1,19 +1,28 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { documentTemplates } from "./utils";
 
-const DocumentViewer = props => {
-  const { tabIndex, document, handleHeightUpdate } = props;
-  const templates = documentTemplates(document, handleHeightUpdate);
-  const Template = templates[tabIndex].template;
+class DocumentViewer extends Component {
+  componentDidMount() {
+    const { updateParentTemplates, document, handleHeightUpdate } = this.props;
+    const templates = documentTemplates(document, handleHeightUpdate);
+    handleHeightUpdate();
+    updateParentTemplates(templates);
+  }
+  render() {
+    const { tabIndex, document, handleHeightUpdate } = this.props;
+    const templates = documentTemplates(document, handleHeightUpdate);
+    const Template = templates[tabIndex].template;
 
-  return <Template document={document} />;
-};
+    return <Template document={document} />;
+  }
+}
 
 DocumentViewer.propTypes = {
   document: PropTypes.object.isRequired,
+  tabIndex: PropTypes.number,
   handleHeightUpdate: PropTypes.func.isRequired,
-  tabIndex: PropTypes.number
+  updateParentTemplates: PropTypes.func
 };
 
 export default DocumentViewer;

--- a/src/components/documentViewer/documentViewer.test.js
+++ b/src/components/documentViewer/documentViewer.test.js
@@ -7,6 +7,9 @@ jest.mock("./utils", () => ({
   documentTemplates: jest.fn()
 }));
 
+const mockUpdateParentHeight = jest.fn();
+const mockUpdateParentTemplates = jest.fn();
+
 it("renders the right template depending on the tabIndex", () => {
   /* eslint-disable */
   documentTemplates.mockReturnValue([
@@ -19,10 +22,15 @@ it("renders the right template depending on the tabIndex", () => {
   const component = mount(
     <DocumentViewer
       document={document}
-      handleHeightUpdate={() => {}}
+      handleHeightUpdate={mockUpdateParentHeight}
+      updateParentTemplates={mockUpdateParentTemplates}
       tabIndex={0}
     />
   );
+  // componentDidMount functions should be called
+  expect(mockUpdateParentHeight).toHaveBeenCalled();
+  expect(mockUpdateParentTemplates).toHaveBeenCalled();
+
   // Check content from tab 1
   expect(component.find("#content").text()).toBe("bar");
 

--- a/src/components/documentViewer/documentViewerContainer.iframe.test.js
+++ b/src/components/documentViewer/documentViewerContainer.iframe.test.js
@@ -17,7 +17,8 @@ jest.mock("./utils", () => ({
 
 const mockParent = {
   updateHeight: jest.fn(),
-  updateTemplates: jest.fn()
+  updateTemplates: jest.fn(),
+  selectTemplateTab: jest.fn()
 };
 
 connectToParent.mockReturnValue({ promise: Promise.resolve(mockParent) });
@@ -26,6 +27,7 @@ const resetMocks = () => {
   connectToParent.mockClear();
   mockParent.updateHeight.mockClear();
   mockParent.updateTemplates.mockClear();
+  mockParent.selectTemplateTab.mockClear();
 };
 
 beforeEach(() => {
@@ -56,8 +58,15 @@ it("calls parent frame's updateHeight when updateParentHeight is called", async 
 it("calls parent frame's updateTemplates when updateParentTemplateTabs is called", async () => {
   const component = shallow(<DocumentViewerContainer />);
   resetMocks();
-  await component.instance().updateParentTemplateTabs();
+  await component.instance().updateParentTemplateTabs(mockDocumentTemplateTabs);
   expect(mockParent.updateTemplates).toHaveBeenCalledWith(
     mockDocumentTemplateTabs
   );
+});
+
+it("calls parent frame's selectTemplateTab when selectTemplateTab is called", async () => {
+  const component = shallow(<DocumentViewerContainer />);
+  resetMocks();
+  await component.instance().selectTemplateTab(1);
+  expect(mockParent.selectTemplateTab).toHaveBeenCalledWith(1);
 });

--- a/src/components/documentViewer/documentViewerContainer.iframe.test.js
+++ b/src/components/documentViewer/documentViewerContainer.iframe.test.js
@@ -63,10 +63,3 @@ it("calls parent frame's updateTemplates when updateParentTemplateTabs is called
     mockDocumentTemplateTabs
   );
 });
-
-it("calls parent frame's selectTemplateTab when selectTemplateTab is called", async () => {
-  const component = shallow(<DocumentViewerContainer />);
-  resetMocks();
-  await component.instance().selectTemplateTab(1);
-  expect(mockParent.selectTemplateTab).toHaveBeenCalledWith(1);
-});

--- a/src/components/documentViewer/documentViewerContainer.js
+++ b/src/components/documentViewer/documentViewerContainer.js
@@ -3,7 +3,7 @@ import connectToParent from "penpal/lib/connectToParent";
 import DocumentViewer from "./documentViewer";
 import { documentTemplateTabs, inIframe } from "./utils";
 
-export const HEIGHT_OFFSET = 30; // Height offset to prevent double scrollbar in certain browsers
+export const HEIGHT_OFFSET = 60; // Height offset to prevent double scrollbar in certain browsers
 class DocumentViewerContainer extends Component {
   constructor(props) {
     super(props);
@@ -29,9 +29,7 @@ class DocumentViewerContainer extends Component {
       const { parentFrameConnection } = this.state;
       const parent = await parentFrameConnection;
       if (parent.updateHeight)
-        await parent.updateHeight(
-          document.documentElement.offsetHeight + HEIGHT_OFFSET
-        );
+        await parent.updateHeight(document.documentElement.offsetHeight);
     }
   }
 

--- a/src/components/documentViewer/documentViewerContainer.js
+++ b/src/components/documentViewer/documentViewerContainer.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-
 import connectToParent from "penpal/lib/connectToParent";
 import DocumentViewer from "./documentViewer";
 import { documentTemplateTabs, inIframe } from "./utils";
@@ -44,7 +43,14 @@ class DocumentViewerContainer extends Component {
     }
   }
 
-  selectTemplateTab(tabIndex) {
+  async selectTemplateTab(tabIndex) {
+    if (inIframe()) {
+      const { parentFrameConnection } = this.state;
+      const parent = await parentFrameConnection;
+      if (parent.selectTemplateTab) {
+        await parent.selectTemplateTab(tabIndex);
+      }
+    }
     this.setState({ tabIndex });
   }
 
@@ -53,7 +59,6 @@ class DocumentViewerContainer extends Component {
   }
 
   componentDidUpdate() {
-    this.updateParentTemplateTabs();
     this.updateParentHeight();
   }
 
@@ -87,6 +92,7 @@ class DocumentViewerContainer extends Component {
         document={this.state.document}
         tabIndex={this.state.tabIndex}
         handleHeightUpdate={this.updateParentHeight}
+        updateParentTemplates={this.updateParentTemplateTabs}
       />
     );
   }

--- a/src/components/documentViewer/documentViewerContainer.js
+++ b/src/components/documentViewer/documentViewerContainer.js
@@ -34,13 +34,14 @@ class DocumentViewerContainer extends Component {
   }
 
   // Use postMessage to update iframe's parent on the selection of templates available for this document
-  async updateParentTemplateTabs() {
+  async updateParentTemplateTabs(templates) {
     if (inIframe()) {
       const { parentFrameConnection } = this.state;
       const parent = await parentFrameConnection;
       if (parent.updateTemplates)
-        await parent.updateTemplates(documentTemplateTabs(this.state.document));
+        await parent.updateTemplates(documentTemplateTabs(templates));
     }
+    this.setState({ templates });
   }
 
   async selectTemplateTab(tabIndex) {
@@ -51,6 +52,10 @@ class DocumentViewerContainer extends Component {
     this.setState({ document });
   }
 
+  getTemplates() {
+    return this.state.templates;
+  }
+
   componentDidUpdate() {
     this.updateParentHeight();
   }
@@ -58,10 +63,12 @@ class DocumentViewerContainer extends Component {
   componentDidMount() {
     const renderDocument = this.handleDocumentChange;
     const selectTemplateTab = this.selectTemplateTab;
+    const getTemplates = () => this.state.templates;
 
     window.openAttestation = {
       renderDocument,
-      selectTemplateTab
+      selectTemplateTab,
+      getTemplates
     };
 
     if (inIframe()) {

--- a/src/components/documentViewer/documentViewerContainer.js
+++ b/src/components/documentViewer/documentViewerContainer.js
@@ -44,13 +44,6 @@ class DocumentViewerContainer extends Component {
   }
 
   async selectTemplateTab(tabIndex) {
-    if (inIframe()) {
-      const { parentFrameConnection } = this.state;
-      const parent = await parentFrameConnection;
-      if (parent.selectTemplateTab) {
-        await parent.selectTemplateTab(tabIndex);
-      }
-    }
     this.setState({ tabIndex });
   }
 

--- a/src/components/documentViewer/documentViewerContainer.js
+++ b/src/components/documentViewer/documentViewerContainer.js
@@ -3,7 +3,7 @@ import connectToParent from "penpal/lib/connectToParent";
 import DocumentViewer from "./documentViewer";
 import { documentTemplateTabs, inIframe } from "./utils";
 
-export const HEIGHT_OFFSET = 60; // Height offset to prevent double scrollbar in certain browsers
+export const HEIGHT_OFFSET = 30; // Height offset to prevent double scrollbar in certain browsers
 class DocumentViewerContainer extends Component {
   constructor(props) {
     super(props);
@@ -29,7 +29,9 @@ class DocumentViewerContainer extends Component {
       const { parentFrameConnection } = this.state;
       const parent = await parentFrameConnection;
       if (parent.updateHeight)
-        await parent.updateHeight(document.documentElement.offsetHeight);
+        await parent.updateHeight(
+          document.documentElement.offsetHeight + HEIGHT_OFFSET
+        );
     }
   }
 

--- a/src/components/documentViewer/utils/index.js
+++ b/src/components/documentViewer/utils/index.js
@@ -18,13 +18,8 @@ export const documentTemplates = (document, handleHeightUpdate) => {
   return [...selectedTemplate, ...templatesFromAttachments];
 };
 
-export const documentTemplateTabs = document => {
-  const templates = documentTemplates(document);
-  return templates.map(template => ({
-    id: template.id,
-    label: template.label
-  }));
-};
+export const documentTemplateTabs = template =>
+  template ? template.map(o => ({ label: o.label, id: o.id })) : null;
 
 // Originally using https://tommcfarlin.com/check-if-a-page-is-in-an-iframe/
 // Currently using https://stackoverflow.com/questions/326069/how-to-identify-if-a-webpage-is-being-loaded-inside-an-iframe-or-directly-into-t

--- a/src/components/documentViewer/utils/utils.test.js
+++ b/src/components/documentViewer/utils/utils.test.js
@@ -63,12 +63,29 @@ describe("documentTemplates", () => {
 
 describe("documentTemplateTabs", () => {
   it("returns only the id and label of the template object", () => {
-    const document = { $template: { name: "custom" } };
-    const templates = documentTemplateTabs(document);
-    expect(templates).toEqual([
+    const templates = [
+      { id: "custom", label: "CUSTOM_TEMPLATE", template: "TEMPLATE_FN" },
+      {
+        id: "attachment1",
+        label: "TEMPLATE_FROM_ATTACHMENT1",
+        template: "TEMPLATE_FN"
+      },
+      {
+        id: "attachment2",
+        label: "TEMPLATE_FROM_ATTACHMENT2",
+        template: "TEMPLATE_FN"
+      }
+    ];
+    expect(documentTemplateTabs(templates)).toEqual([
       { id: "custom", label: "CUSTOM_TEMPLATE" },
-      { id: "attachment1", label: "TEMPLATE_FROM_ATTACHMENT1" },
-      { id: "attachment2", label: "TEMPLATE_FROM_ATTACHMENT2" }
+      {
+        id: "attachment1",
+        label: "TEMPLATE_FROM_ATTACHMENT1"
+      },
+      {
+        id: "attachment2",
+        label: "TEMPLATE_FROM_ATTACHMENT2"
+      }
     ]);
   });
 });


### PR DESCRIPTION
Remove the updateParentTemplateTabs function when component updates in documentViewerContainer.js otherwise when we switch tabs, the view keeps switching between the selected tab and the first tab.

Instead, we pass the updateParentTemplateTabs function to the child component, documentViewer.js and updates templates once when componentDidMounts in documentViewer.