### PR TITLE
Feat(getTemplates): Added function getTemplates

### DIFF
--- a/src/components/documentViewer/documentViewerContainer.iframe.test.js
+++ b/src/components/documentViewer/documentViewerContainer.iframe.test.js
@@ -63,10 +63,3 @@ it("calls parent frame's updateTemplates when updateParentTemplateTabs is called
     mockDocumentTemplateTabs
   );
 });
-
-it("calls parent frame's selectTemplateTab when selectTemplateTab is called", async () => {
-  const component = shallow(<DocumentViewerContainer />);
-  resetMocks();
-  await component.instance().selectTemplateTab(1);
-  expect(mockParent.selectTemplateTab).toHaveBeenCalledWith(1);
-});

--- a/src/components/documentViewer/documentViewerContainer.js
+++ b/src/components/documentViewer/documentViewerContainer.js
@@ -12,7 +12,6 @@ class DocumentViewerContainer extends Component {
     this.selectTemplateTab = this.selectTemplateTab.bind(this);
     this.updateParentHeight = this.updateParentHeight.bind(this);
     this.updateParentTemplateTabs = this.updateParentTemplateTabs.bind(this);
-    this.getTemplates = this.getTemplates.bind(this);
     this.state = {
       parentFrameConnection: null,
       document: null,
@@ -46,13 +45,6 @@ class DocumentViewerContainer extends Component {
   }
 
   async selectTemplateTab(tabIndex) {
-    if (inIframe()) {
-      const { parentFrameConnection } = this.state;
-      const parent = await parentFrameConnection;
-      if (parent.selectTemplateTab) {
-        await parent.selectTemplateTab(tabIndex);
-      }
-    }
     this.setState({ tabIndex });
   }
 
@@ -71,7 +63,7 @@ class DocumentViewerContainer extends Component {
   componentDidMount() {
     const renderDocument = this.handleDocumentChange;
     const selectTemplateTab = this.selectTemplateTab;
-    const getTemplates = this.getTemplates;
+    const getTemplates = () => this.state.templates;
 
     window.openAttestation = {
       renderDocument,

--- a/src/components/documentViewer/documentViewerContainer.js
+++ b/src/components/documentViewer/documentViewerContainer.js
@@ -12,6 +12,7 @@ class DocumentViewerContainer extends Component {
     this.selectTemplateTab = this.selectTemplateTab.bind(this);
     this.updateParentHeight = this.updateParentHeight.bind(this);
     this.updateParentTemplateTabs = this.updateParentTemplateTabs.bind(this);
+    this.getTemplates = this.getTemplates.bind(this);
     this.state = {
       parentFrameConnection: null,
       document: null,
@@ -34,13 +35,14 @@ class DocumentViewerContainer extends Component {
   }
 
   // Use postMessage to update iframe's parent on the selection of templates available for this document
-  async updateParentTemplateTabs() {
+  async updateParentTemplateTabs(templates) {
     if (inIframe()) {
       const { parentFrameConnection } = this.state;
       const parent = await parentFrameConnection;
       if (parent.updateTemplates)
-        await parent.updateTemplates(documentTemplateTabs(this.state.document));
+        await parent.updateTemplates(documentTemplateTabs(templates));
     }
+    this.setState({ templates });
   }
 
   async selectTemplateTab(tabIndex) {
@@ -58,6 +60,10 @@ class DocumentViewerContainer extends Component {
     this.setState({ document });
   }
 
+  getTemplates() {
+    return this.state.templates;
+  }
+
   componentDidUpdate() {
     this.updateParentHeight();
   }
@@ -65,10 +71,12 @@ class DocumentViewerContainer extends Component {
   componentDidMount() {
     const renderDocument = this.handleDocumentChange;
     const selectTemplateTab = this.selectTemplateTab;
+    const getTemplates = this.getTemplates;
 
     window.openAttestation = {
       renderDocument,
-      selectTemplateTab
+      selectTemplateTab,
+      getTemplates
     };
 
     if (inIframe()) {

--- a/src/components/documentViewer/utils/index.js
+++ b/src/components/documentViewer/utils/index.js
@@ -18,13 +18,8 @@ export const documentTemplates = (document, handleHeightUpdate) => {
   return [...selectedTemplate, ...templatesFromAttachments];
 };
 
-export const documentTemplateTabs = document => {
-  const templates = documentTemplates(document);
-  return templates.map(template => ({
-    id: template.id,
-    label: template.label
-  }));
-};
+export const documentTemplateTabs = template =>
+  template ? template.map(o => ({ label: o.label, id: o.id })) : null;
 
 // Originally using https://tommcfarlin.com/check-if-a-page-is-in-an-iframe/
 // Currently using https://stackoverflow.com/questions/326069/how-to-identify-if-a-webpage-is-being-loaded-inside-an-iframe-or-directly-into-t

--- a/src/components/documentViewer/utils/utils.test.js
+++ b/src/components/documentViewer/utils/utils.test.js
@@ -63,12 +63,31 @@ describe("documentTemplates", () => {
 
 describe("documentTemplateTabs", () => {
   it("returns only the id and label of the template object", () => {
-    const document = { $template: { name: "custom" } };
-    const templates = documentTemplateTabs(document);
-    expect(templates).toEqual([
-      { id: "custom", label: "CUSTOM_TEMPLATE" },
-      { id: "attachment1", label: "TEMPLATE_FROM_ATTACHMENT1" },
-      { id: "attachment2", label: "TEMPLATE_FROM_ATTACHMENT2" }
+    const templates = [
+      { id: "custom", label: "CUSTOM_TEMPLATE", template: "TEMPLATE_FN" },
+      {
+        id: "attachment1",
+        label: "TEMPLATE_FROM_ATTACHMENT1",
+        template: "TEMPLATE_FN"
+      },
+      {
+        id: "attachment2",
+        label: "TEMPLATE_FROM_ATTACHMENT2",
+        template: "TEMPLATE_FN"
+      }
+    ];
+    expect(documentTemplateTabs(templates)).toEqual([
+      { id: "custom", label: "CUSTOM_TEMPLATE", template: undefined },
+      {
+        id: "attachment1",
+        label: "TEMPLATE_FROM_ATTACHMENT1",
+        template: undefined
+      },
+      {
+        id: "attachment2",
+        label: "TEMPLATE_FROM_ATTACHMENT2",
+        template: undefined
+      }
     ]);
   });
 });

--- a/src/components/documentViewer/utils/utils.test.js
+++ b/src/components/documentViewer/utils/utils.test.js
@@ -77,16 +77,14 @@ describe("documentTemplateTabs", () => {
       }
     ];
     expect(documentTemplateTabs(templates)).toEqual([
-      { id: "custom", label: "CUSTOM_TEMPLATE", template: undefined },
+      { id: "custom", label: "CUSTOM_TEMPLATE" },
       {
         id: "attachment1",
-        label: "TEMPLATE_FROM_ATTACHMENT1",
-        template: undefined
+        label: "TEMPLATE_FROM_ATTACHMENT1"
       },
       {
         id: "attachment2",
-        label: "TEMPLATE_FROM_ATTACHMENT2",
-        template: undefined
+        label: "TEMPLATE_FROM_ATTACHMENT2"
       }
     ]);
   });


### PR DESCRIPTION
Merge to branch tabs first.

Added function getTemplates() to documentViewerContainer.

Changed updateParentTemplateTabs to accept a parameter - templates, which assigns this.state.templates to the document's templates.

User can call getTemplates while testing the integration tests to see if the proper templates are being passed in:
eg.
  const templates = await t.eval(() => window.openAttestation.getTemplates());
  await t
    .expect(templates)
    .eql([
      { id: "certificate", label: "Certificate", template: undefined },
      { id: "transcript", label: "Transcript", template: undefined },
      { id: "media", label: "Media", template: undefined }
    ]);