### PR TITLE
Fix(updateTemplateTab): Change updateTemplateTab implementation & add getTemplates

### DIFF
--- a/src/components/documentViewer/documentViewer.js
+++ b/src/components/documentViewer/documentViewer.js
@@ -6,6 +6,7 @@ const DocumentViewer = props => {
   const { tabIndex, document, handleHeightUpdate } = props;
   const templates = documentTemplates(document, handleHeightUpdate);
   const Template = templates[tabIndex].template;
+  handleHeightUpdate();
 
   return <Template document={document} />;
 };

--- a/src/components/documentViewer/documentViewer.js
+++ b/src/components/documentViewer/documentViewer.js
@@ -6,7 +6,6 @@ const DocumentViewer = props => {
   const { tabIndex, document, handleHeightUpdate } = props;
   const templates = documentTemplates(document, handleHeightUpdate);
   const Template = templates[tabIndex].template;
-  handleHeightUpdate();
 
   return <Template document={document} />;
 };

--- a/src/components/documentViewer/documentViewerContainer.js
+++ b/src/components/documentViewer/documentViewerContainer.js
@@ -36,11 +36,14 @@ class DocumentViewerContainer extends Component {
 
   // Use postMessage to update iframe's parent on the selection of templates available for this document
   async updateParentTemplateTabs() {
+    const templates = await documentTemplateTabs(this.state.document);
+    this.setState({ templates });
     if (inIframe()) {
       const { parentFrameConnection } = this.state;
       const parent = await parentFrameConnection;
-      if (parent.updateTemplates)
+      if (parent.updateTemplates) {
         await parent.updateTemplates(documentTemplateTabs(this.state.document));
+      }
     }
   }
 
@@ -50,20 +53,22 @@ class DocumentViewerContainer extends Component {
 
   handleDocumentChange(document) {
     this.setState({ document });
+    this.updateParentTemplateTabs();
   }
 
   componentDidUpdate() {
-    this.updateParentTemplateTabs();
     this.updateParentHeight();
   }
 
   componentDidMount() {
     const renderDocument = this.handleDocumentChange;
     const selectTemplateTab = this.selectTemplateTab;
+    const getTemplates = () => this.state.templates;
 
     window.openAttestation = {
       renderDocument,
-      selectTemplateTab
+      selectTemplateTab,
+      getTemplates
     };
 
     if (inIframe()) {

--- a/src/components/documentViewer/documentViewerContainer.test.js
+++ b/src/components/documentViewer/documentViewerContainer.test.js
@@ -5,7 +5,8 @@ import { shallow } from "enzyme";
 jest.mock("./documentViewer", () => jest.fn());
 
 jest.mock("./utils", () => ({
-  inIframe: () => false
+  inIframe: () => false,
+  documentTemplateTabs: () => jest.fn()
 }));
 
 it("returns null if there are no document", () => {


### PR DESCRIPTION
Change implementation of updateTemplateTab from componentShouldUpdate() to handleDocumentChange to prevent the tabs from switching between the selected tab and the original tab. 

Also, added the function getTemplates() to be used for integration tests. This sets the state of documentViewerContainer to the corresponding template array when we updateTemplateTabs.